### PR TITLE
Catch exceptions thrown in HTTP library

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -159,7 +159,7 @@ Dev {
       }
       epaye {
         host = localhost
-        port = 8105
+        port = 8090
       }
       service-locator {
         host = localhost

--- a/test/uk/gov/hmrc/epayeapi/connectors/ConnectorSpec.scala
+++ b/test/uk/gov/hmrc/epayeapi/connectors/ConnectorSpec.scala
@@ -22,7 +22,8 @@ import org.scalatest.mock.MockitoSugar
 import play.api.http.Status
 import play.api.libs.json.{JsError, JsPath, Json}
 import uk.gov.hmrc.epayeapi.models.in._
-import uk.gov.hmrc.play.http.{HeaderCarrier, HttpGet, HttpResponse}
+import uk.gov.hmrc.play.http.hooks.HttpHook
+import uk.gov.hmrc.play.http._
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -81,6 +82,31 @@ class ConnectorSpec extends UnitSpec with MockitoSugar with ScalaFutures {
         }
 
       connector.getData.futureValue shouldEqual ApiNotFound[TestData]()
+    }
+
+    "return ApiNotFound on 404 exceptions" in new Setup {
+      // Hacky. Http exceptions are checked but `http.GET` has not defined
+      // any checked exceptions as throwble. Therefore mockito won't allow a
+      // `.thenThrow`. So we have to create a subclass and override the method.
+      val thisConnector = new TestConnector(new HttpGet {
+        override protected def doGet(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = ???
+        override def GET[A](url: String)(implicit rds: HttpReads[A], hc: HeaderCarrier): Future[A] = Future(throw new NotFoundException("Not found"))
+        override val hooks: Seq[HttpHook] = Seq.empty
+      }, global)
+
+      thisConnector.getData.futureValue shouldEqual ApiNotFound[TestData]()
+    }
+    "return ApiError on unexpected responses with status < 500" in new Setup {
+      // Hacky. Http exceptions are checked but `http.GET` has not defined
+      // any checked exceptions as throwble. Therefore mockito won't allow a
+      // `.thenThrow`. So we have to create a subclass and override the method.
+      val thisConnector = new TestConnector(new HttpGet {
+        override protected def doGet(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = ???
+        override def GET[A](url: String)(implicit rds: HttpReads[A], hc: HeaderCarrier): Future[A] = Future(throw new ForbiddenException("Forbidden"))
+        override val hooks: Seq[HttpHook] = Seq.empty
+      }, global)
+
+      thisConnector.getData.futureValue shouldEqual ApiError[TestData](Status.FORBIDDEN, "Forbidden")
     }
 
     "return ApiError on unexpected status codes from upstream" in new Setup {


### PR DESCRIPTION
Turns out errors are thrown and not returned as responses